### PR TITLE
Apply Quiet Flag to PHPCS Commmand

### DIFF
--- a/lib/pronto/phpcs.rb
+++ b/lib/pronto/phpcs.rb
@@ -36,7 +36,7 @@ module Pronto
       escaped_standard = Shellwords.escape(@standard)
       escaped_path = Shellwords.escape(path)
 
-      JSON.parse(`#{escaped_executable} --report=json --standard=#{escaped_standard} #{escaped_path}`)
+      JSON.parse(`#{escaped_executable} -q --report=json --standard=#{escaped_standard} #{escaped_path}`)
         .fetch('files', {})
         .fetch(path, {})
         .fetch('messages', [])


### PR DESCRIPTION
When we set `PRONTO_PHPCS_STANDARD` to `phpcs.xml` (phpcs config file), this
will generate below command:

```
phpcs --report=json --standard=phpcs.xml <filepath>
```

And this will output below:

```
{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{}}Time: 39ms; Memory: 4Mb
```

The trailing time taken report causes the `JSON.parse` to throw an error.

The fix is to apply `-q` (quite) flag to the command so that it does not output the time taken report.

```
phpcs -q --report=json --standard=phpcs.xml <filepath>
```

And this will output below:

```
{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{}}
```